### PR TITLE
Update awake_start

### DIFF
--- a/run/awake_start
+++ b/run/awake_start
@@ -10,7 +10,7 @@ else
     while true
     do
       if [[ -n "${TESSIE_API_TOKEN:+x}" ]]
-      # Use Tessie API to nudge the car
+      #Use Tessie API to nudge the car
       then
         http_response=$(curl -s -w "%{http_code}" \
           -H "Authorization: Bearer $TESSIE_API_TOKEN" \
@@ -18,14 +18,15 @@ else
           -H "User-Agent: github.com/marcone/teslausb" \
           "https://api.tessie.com/$TESSIE_VIN/command/close_charge_port")
 
-        log "Tessie: Nudging the car."
-        # Extract HTTP status code
+        #log "Tessie: Nudging the car." #commented out to reduce log spam
+
+        #Extract HTTP status code
         http_status="${http_response: -3}"
         
-        # Check if HTTP status code is not 200 (OK)
+        #Check if HTTP status code is not 200 (OK)
         if [ "$http_status" != "200" ]
         then
-          # Log an error
+          #Log an error
           log "Tessie: Failed to send command. Check your TESSIE_API_TOKEN and TESSIE_VIN are set correctly. If they are, your car may be offline or asleep."
           if [ "$retry" -lt "3" ]
           then
@@ -41,20 +42,20 @@ else
       fi
 
       if [[ -n "${TESLA_BLE_VIN:+x}" ]]
-      # Use Tesla BLE API to nudge the car
+      #Use Tesla BLE API to nudge the car
       then
         if BLE_response=$(/root/bin/tesla-control -ble -key-file /root/.ble/key_private.pem -vin "${TESLA_BLE_VIN^^}" charge-port-close 2>&1)
         then
-          # BLE success
-          log "Tesla BLE: Successfully nudged the car to stay awake."
+          #BLE success
+          #log "Tesla BLE: Successfully nudged the car to stay awake." #commented out to reduce log spam
 
         elif [[ ( "$BLE_response" == *"already closed"* ) || ( "$BLE_response" == *"cable connected"* ) ]]
-          # Acceptable false-negative BLE responses
+          #Acceptable false-negative BLE responses
           then
           log "Tesla BLE: Successfully nudged the car to stay awake."
         
         else  
-          # Log error and retry
+          #Log error and retry
           log "Tesla BLE: Failed to nudge the car. There may be an issue with the BLE communication."
           if [ "$retry" -lt "3" ]
           then
@@ -76,12 +77,12 @@ else
 
   case "${SENTRY_CASE}" in
     1)
-      # Sentry Mode should already be enabled
+      #Sentry Mode should already be enabled
       log "Skip sending command to enable Sentry Mode."
       ;;
     2)
       if [[ ( -n "${TESLAFI_API_TOKEN:+x}" ) ]]
-      # Use TeslaFi API to enable Sentry Mode
+      #Use TeslaFi API to enable Sentry Mode
       then
         http_response=$(curl -s -w "%{http_code}" \
           -H "Authorization: Bearer $TESLAFI_API_TOKEN" \
@@ -91,24 +92,24 @@ else
 
         log "TeslaFi: Command sent to enable Sentry Mode."
 
-        # Extract HTTP status code
+        #Extract HTTP status code
         http_status="${http_response: -3}"
                 
-        # Extract response body (excluding status code)
+        #Extract response body (excluding status code)
         response_body="${http_response:0:${#http_response}-3}"
 
-        # Check if HTTP status code is not 200 (OK)
+        #Check if HTTP status code is not 200 (OK)
         if [ "$http_status" != "200" ]
         then
-          # Log an error
+          #Log an error
           log "TeslaFi: Failed to set Sentry Mode. Check your TESLAFI_API_TOKEN is set correctly. If it is, your car may be offline or asleep."
         else
-          # Check if the response is in JSON format
+          #Check if the response is in JSON format
           if ! jq -e . >/dev/null 2>&1 <<<"$response_body"
           then
             log "TeslaFi: Failed to set Sentry Mode."
           else
-            # Parse JSON and check if "result" is true
+            #Parse JSON and check if "result" is true
             result1=$(jq -r '.response' <<<"$response_body")
             result2=$(jq -r '.result' <<<"$result1")
             request_counter=$(jq -r '.tesla_request_counter' <<<"$response_body")
@@ -123,7 +124,7 @@ else
           fi
         fi
       elif [[ -n "${TESSIE_API_TOKEN:+x}" ]]
-      # Use Tessie API to enable Sentry Mode
+      #Use Tessie API to enable Sentry Mode
       then
         http_response=$(curl -s -w "%{http_code}" \
           -H "Authorization: Bearer $TESSIE_API_TOKEN" \
@@ -132,24 +133,24 @@ else
           "https://api.tessie.com/$TESSIE_VIN/command/enable_sentry")
 
         log "Tessie: Command sent to enable Sentry Mode."
-        # Extract HTTP status code
+        #Extract HTTP status code
         http_status="${http_response: -3}"
         
-        # Extract response body (excluding status code)
+        #Extract response body (excluding status code)
         response_body="${http_response:0:${#http_response}-3}"
         
-        # Check if HTTP status code is not 200 (OK)
+        #Check if HTTP status code is not 200 (OK)
         if [ "$http_status" != "200" ]
         then
-          # Log an error
+          #Log an error
           log "Tessie: Failed to set Sentry Mode. Check your TESSIE_API_TOKEN and TESSIE_VIN are set correctly. If they are, your car may not have a good connection."
         else
-          # Check if the response is in JSON format
+          #Check if the response is in JSON format
           if ! jq -e . >/dev/null 2>&1 <<<"$response_body"
           then
             log "Tessie: Failed to set Sentry Mode. Response data: $response_body"
           else
-            # Parse JSON and check if "result" is true
+            #Parse JSON and check if "result" is true
             result=$(jq -r '.result' <<<"$response_body")
             if [[ "$result" != "true" ]]
             then
@@ -158,7 +159,7 @@ else
           fi
         fi
       elif [[ -n "${TESLA_BLE_VIN:+x}" ]]
-      # Use Tesla BLE API to enable Sentry Mode
+      #Use Tesla BLE API to enable Sentry Mode
       then
         if /root/bin/tesla-control -ble -key-file /root/.ble/key_private.pem -vin "${TESLA_BLE_VIN^^}" sentry-mode on
         then
@@ -169,7 +170,7 @@ else
       fi
       ;;
     3)
-      # Nudge car periodically without using Sentry Mode
+      #Nudge car periodically without using Sentry Mode
       log "Starting background task to keep car awake."
       nudge &
       echo $! > /tmp/keep_awake_task_pid

--- a/run/awake_start
+++ b/run/awake_start
@@ -74,12 +74,6 @@ else
     done
   }
 
-  if [[ -z "${SENTRY_CASE:+x}" && -n "${TESLA_BLE_VIN:+x}" ]]
-  then
-    # If BLE Sentry unset, can assume mode 3 
-    SENTRY_CASE=3
-  fi
-
   case "${SENTRY_CASE}" in
     1)
       # Sentry Mode should already be enabled

--- a/run/awake_start
+++ b/run/awake_start
@@ -18,8 +18,6 @@ else
           -H "User-Agent: github.com/marcone/teslausb" \
           "https://api.tessie.com/$TESSIE_VIN/command/close_charge_port")
 
-        #log "Tessie: Nudging the car." #commented out to reduce log spam
-
         #Extract HTTP status code
         http_status="${http_response: -3}"
         
@@ -42,30 +40,25 @@ else
       fi
 
       if [[ -n "${TESLA_BLE_VIN:+x}" ]]
-      #Use Tesla BLE API to nudge the car
+      #use Tesla BLE API to nudge the car
       then
-        if BLE_response=$(/root/bin/tesla-control -ble -key-file /root/.ble/key_private.pem -vin "${TESLA_BLE_VIN^^}" charge-port-close 2>&1)
+        if ! BLE_response=$(/root/bin/tesla-control -ble -key-file /root/.ble/key_private.pem -vin "${TESLA_BLE_VIN^^}" charge-port-close 2>&1)
         then
-          #BLE success
-          #log "Tesla BLE: Successfully nudged the car to stay awake." #commented out to reduce log spam
-
-        elif [[ ( "$BLE_response" == *"already closed"* ) || ( "$BLE_response" == *"cable connected"* ) ]]
-          #Acceptable false-negative BLE responses
+          #check false-negative BLE responses
+          if [[ ( "$BLE_response" != *"already closed"* ) && ( "$BLE_response" != *"cable connected"* ) ]]
           then
-          log "Tesla BLE: Successfully nudged the car to stay awake."
-        
-        else  
-          #Log error and retry
-          log "Tesla BLE: Failed to nudge the car. There may be an issue with the BLE communication."
-          if [ "$retry" -lt "3" ]
-          then
-            log "Tesla BLE: Retrying after 30s in case the connection was poor."
-            retry=$((retry+1))
-            sleep 30
-            continue
-          else
-            log "Tesla BLE: $BLE_response"
-            break
+            #log error and retry
+            log "Tesla BLE: Failed to nudge the car. There may be an issue with the BLE communication."
+            if [ "$retry" -lt "3" ]
+            then
+              log "Tesla BLE: Retrying after 30s in case the connection was poor."
+              retry=$((retry+1))
+              sleep 30
+              continue
+            else
+              log "Tesla BLE: $BLE_response"
+              break
+            fi
           fi
         fi
       fi

--- a/run/awake_start
+++ b/run/awake_start
@@ -10,7 +10,7 @@ else
     while true
     do
       if [[ -n "${TESSIE_API_TOKEN:+x}" ]]
-      #Use Tessie API to nudge the car
+      # Use Tessie API to nudge the car
       then
         http_response=$(curl -s -w "%{http_code}" \
           -H "Authorization: Bearer $TESSIE_API_TOKEN" \
@@ -18,13 +18,13 @@ else
           -H "User-Agent: github.com/marcone/teslausb" \
           "https://api.tessie.com/$TESSIE_VIN/command/close_charge_port")
 
-        #Extract HTTP status code
+        # Extract HTTP status code
         http_status="${http_response: -3}"
         
-        #Check if HTTP status code is not 200 (OK)
+        # Check if HTTP status code is not 200 (OK)
         if [ "$http_status" != "200" ]
         then
-          #Log an error
+          # Log an error
           log "Tessie: Failed to send command. Check your TESSIE_API_TOKEN and TESSIE_VIN are set correctly. If they are, your car may be offline or asleep."
           if [ "$retry" -lt "3" ]
           then
@@ -40,14 +40,14 @@ else
       fi
 
       if [[ -n "${TESLA_BLE_VIN:+x}" ]]
-      #use Tesla BLE API to nudge the car
+      # use Tesla BLE API to nudge the car
       then
         if ! BLE_response=$(/root/bin/tesla-control -ble -key-file /root/.ble/key_private.pem -vin "${TESLA_BLE_VIN^^}" charge-port-close 2>&1)
         then
-          #check false-negative BLE responses
+          # check false-negative BLE responses
           if [[ ( "$BLE_response" != *"already closed"* ) && ( "$BLE_response" != *"cable connected"* ) ]]
           then
-            #log error and retry
+            # log error and retry
             log "Tesla BLE: Failed to nudge the car. There may be an issue with the BLE communication."
             if [ "$retry" -lt "3" ]
             then
@@ -70,12 +70,12 @@ else
 
   case "${SENTRY_CASE}" in
     1)
-      #Sentry Mode should already be enabled
+      # Sentry Mode should already be enabled
       log "Skip sending command to enable Sentry Mode."
       ;;
     2)
       if [[ ( -n "${TESLAFI_API_TOKEN:+x}" ) ]]
-      #Use TeslaFi API to enable Sentry Mode
+      # Use TeslaFi API to enable Sentry Mode
       then
         http_response=$(curl -s -w "%{http_code}" \
           -H "Authorization: Bearer $TESLAFI_API_TOKEN" \
@@ -85,24 +85,24 @@ else
 
         log "TeslaFi: Command sent to enable Sentry Mode."
 
-        #Extract HTTP status code
+        # Extract HTTP status code
         http_status="${http_response: -3}"
                 
-        #Extract response body (excluding status code)
+        # Extract response body (excluding status code)
         response_body="${http_response:0:${#http_response}-3}"
 
-        #Check if HTTP status code is not 200 (OK)
+        # Check if HTTP status code is not 200 (OK)
         if [ "$http_status" != "200" ]
         then
-          #Log an error
+          # Log an error
           log "TeslaFi: Failed to set Sentry Mode. Check your TESLAFI_API_TOKEN is set correctly. If it is, your car may be offline or asleep."
         else
-          #Check if the response is in JSON format
+          # Check if the response is in JSON format
           if ! jq -e . >/dev/null 2>&1 <<<"$response_body"
           then
             log "TeslaFi: Failed to set Sentry Mode."
           else
-            #Parse JSON and check if "result" is true
+            # Parse JSON and check if "result" is true
             result1=$(jq -r '.response' <<<"$response_body")
             result2=$(jq -r '.result' <<<"$result1")
             request_counter=$(jq -r '.tesla_request_counter' <<<"$response_body")
@@ -117,7 +117,7 @@ else
           fi
         fi
       elif [[ -n "${TESSIE_API_TOKEN:+x}" ]]
-      #Use Tessie API to enable Sentry Mode
+      # Use Tessie API to enable Sentry Mode
       then
         http_response=$(curl -s -w "%{http_code}" \
           -H "Authorization: Bearer $TESSIE_API_TOKEN" \
@@ -126,24 +126,24 @@ else
           "https://api.tessie.com/$TESSIE_VIN/command/enable_sentry")
 
         log "Tessie: Command sent to enable Sentry Mode."
-        #Extract HTTP status code
+        # Extract HTTP status code
         http_status="${http_response: -3}"
         
-        #Extract response body (excluding status code)
+        # Extract response body (excluding status code)
         response_body="${http_response:0:${#http_response}-3}"
         
-        #Check if HTTP status code is not 200 (OK)
+        # Check if HTTP status code is not 200 (OK)
         if [ "$http_status" != "200" ]
         then
-          #Log an error
+          # Log an error
           log "Tessie: Failed to set Sentry Mode. Check your TESSIE_API_TOKEN and TESSIE_VIN are set correctly. If they are, your car may not have a good connection."
         else
-          #Check if the response is in JSON format
+          # Check if the response is in JSON format
           if ! jq -e . >/dev/null 2>&1 <<<"$response_body"
           then
             log "Tessie: Failed to set Sentry Mode. Response data: $response_body"
           else
-            #Parse JSON and check if "result" is true
+            # Parse JSON and check if "result" is true
             result=$(jq -r '.result' <<<"$response_body")
             if [[ "$result" != "true" ]]
             then
@@ -152,7 +152,7 @@ else
           fi
         fi
       elif [[ -n "${TESLA_BLE_VIN:+x}" ]]
-      #Use Tesla BLE API to enable Sentry Mode
+      # Use Tesla BLE API to enable Sentry Mode
       then
         if /root/bin/tesla-control -ble -key-file /root/.ble/key_private.pem -vin "${TESLA_BLE_VIN^^}" sentry-mode on
         then
@@ -163,7 +163,7 @@ else
       fi
       ;;
     3)
-      #Nudge car periodically without using Sentry Mode
+      # Nudge car periodically without using Sentry Mode
       log "Starting background task to keep car awake."
       nudge &
       echo $! > /tmp/keep_awake_task_pid

--- a/setup/pi/configure.sh
+++ b/setup/pi/configure.sh
@@ -198,12 +198,6 @@ function check_teslafi_api () {
       return 1
     fi
 
-    if [ "$number" -eq 1 ] || [ "$number" -eq 2 ]; then
-        echo "The variable is $number"
-    else
-        echo "The variable is neither 1 nor 2"
-    fi
-
     if ! command -v jq &>/dev/null
       then
         log_progress "Installing required package for TeslaFi API: jq"

--- a/setup/pi/configure.sh
+++ b/setup/pi/configure.sh
@@ -193,6 +193,17 @@ function check_at_most_one_wake_api () {
 function check_teslafi_api () {
   if [[ ( -n "${TESLAFI_API_TOKEN:+x}" ) ]]
   then
+    if [[ "$SENTRY_CASE" != 1 && "$SENTRY_CASE" != 2 ]]; then
+      log_progress "STOP: invalid SENTRY_CASE for Tesla API."
+      return 1
+    fi
+
+    if [ "$number" -eq 1 ] || [ "$number" -eq 2 ]; then
+        echo "The variable is $number"
+    else
+        echo "The variable is neither 1 nor 2"
+    fi
+
     if ! command -v jq &>/dev/null
       then
         log_progress "Installing required package for TeslaFi API: jq"
@@ -207,6 +218,11 @@ function check_teslafi_api () {
 function check_tessie_api () {
   if [[ ( -n "${TESSIE_API_TOKEN:+x}" ) ]]
   then
+    if [[ "$SENTRY_CASE" != 1 && "$SENTRY_CASE" != 2 && "$SENTRY_CASE" != 3 ]]; then
+      log_progress "STOP: invalid SENTRY_CASE for Tessie API."
+      return 1
+    fi
+    
     if [[ ( -z "${TESSIE_VIN:+x}" ) ]]
     then
       log_progress "STOP: Tessie API requires the VIN number to be provided."
@@ -229,6 +245,11 @@ function check_and_configure_tesla_ble () {
   local install_path="$1"
   if [[ ( -n "${TESLA_BLE_VIN:+x}" ) ]]
   then
+    if [[ "$SENTRY_CASE" != 1 && "$SENTRY_CASE" != 2 && "$SENTRY_CASE" != 3 ]]; then
+      log_progress "STOP: invalid SENTRY_CASE for Tesla BLE API."
+      return 1
+    fi
+    
     if dpkg-query -W --showformat='${db:Status-Status}\n' "bluez" 2>/dev/null | grep -q '^installed$'
     then
       echo "Skipping required package for Tesla BLE API: bluez already installed."


### PR DESCRIPTION
Fixed legacy code. Removed BLE SENTRY_CASE assumption, which allowed BLE to awake_start without SENTRY_CASE defined in config file. Consequently awake_stop will not be able to execute without the same assumption; car kept awake indefinitely.